### PR TITLE
부가 기능 툴바 및 변환 팝업 스크롤 고정

### DIFF
--- a/EasyDOC-frontend/src/pages/PdfHighlightViewer.css
+++ b/EasyDOC-frontend/src/pages/PdfHighlightViewer.css
@@ -17,11 +17,12 @@
   background: #fff;
   line-height: 0;       /* 캔버스 아래 여백 제거 */
   border-radius: 4px;
-  overflow: hidden;
+  overflow: visible;
 }
 
 .pdf-page-wrapper canvas {
   display: block;
+  border-radius: 4px;
 }
 
 /* ===============================
@@ -101,6 +102,10 @@
   max-width: 900px;
   margin-left: auto;
   margin-right: auto;
+
+  position: sticky;
+  top: 0;
+  z-index: 110;
 }
 
 .memo-tool-btn {
@@ -506,6 +511,10 @@
   font-size: 12.5px;
   color: #1d4ed8;
   line-height: 1.4;
+
+  position: sticky;
+  top: 56px;
+  z-index: 109;
 }
 .fill-mode-banner span {
   flex: 1;
@@ -632,8 +641,8 @@
 }
 
 .pdf-simplify-popup {
-  position: fixed;
-  z-index: 120;
+  position: absolute;
+  z-index: 105;
   transform: translate(-50%, -100%);
   width: min(430px, 80vw);
   max-height: 280px;

--- a/EasyDOC-frontend/src/pages/PdfHighlightViewer.jsx
+++ b/EasyDOC-frontend/src/pages/PdfHighlightViewer.jsx
@@ -431,11 +431,10 @@ function PdfPage({ pdfDoc, pageNum, containerWidth, highlightWord, memoMode, mem
         const selectedRects = extractHighlightRectsFromRect(normalizedSelection);
         const popupX = normalizedSelection.startX + (normalizedSelection.endX - normalizedSelection.startX) / 2;
         const wrapperRect = e.currentTarget.getBoundingClientRect();
-        const preferAboveY = wrapperRect.top + Math.max(8, normalizedSelection.startY - 12);
-        const preferBelowY = wrapperRect.top + normalizedSelection.endY + 12;
-        const placeBelow = preferAboveY < 140;
-        const popupClientX = wrapperRect.left + popupX;
-        const popupClientY = placeBelow ? preferBelowY : preferAboveY;
+        const absoluteTopInViewport = wrapperRect.top + normalizedSelection.startY;
+        const placeBelow = absoluteTopInViewport < 140;
+        const popupLocalX = popupX;
+        const popupLocalY = placeBelow ? normalizedSelection.endY + 12 : Math.max(8, normalizedSelection.startY - 12);
 
         setFixedSelectionRects(selectedRects);
         setSimplifyPopup({
@@ -443,8 +442,8 @@ function PdfPage({ pdfDoc, pageNum, containerWidth, highlightWord, memoMode, mem
           error: null,
           originalText: text.trim(),
           simplifiedText: "",
-          x: popupClientX,
-          y: popupClientY,
+          x: popupLocalX,
+          y: popupLocalY,
           placement: placeBelow ? "below" : "above",
         });
 
@@ -752,8 +751,7 @@ function PdfPage({ pdfDoc, pageNum, containerWidth, highlightWord, memoMode, mem
       ))}
 
       {/* 쉬운말 변환 팝업 (클리핑 방지: body 포털로 렌더링) */}
-      {simplifyPopup
-        ? createPortal(
+      {simplifyPopup && (
             <div
               className={`pdf-simplify-popup ${simplifyPopup.placement === "below" ? "pdf-simplify-popup--below" : ""}`}
               style={{ left: simplifyPopup.x, top: simplifyPopup.y }}
@@ -786,10 +784,8 @@ function PdfPage({ pdfDoc, pageNum, containerWidth, highlightWord, memoMode, mem
                   <p className="pdf-simplify-popup-result">{simplifyPopup.simplifiedText}</p>
                 )}
               </div>
-            </div>,
-            document.body,
-          )
-        : null}
+            </div>
+      )}
 
       {/* 텍스트 레이어 없음 안내 */}
       {!hasText && (


### PR DESCRIPTION
- viewer 페이지에서 부가 기능 툴바가 문서를 스크롤 하여도 상단에서 계속 표시되어 따라오도록 수정
- 양식 채우기 안내 팝업도 동일하게 상단에서 계속 따라오도록 수정
- 글을 드래그하여 생성한 쉬운 변환 팝업이 문서를 스크롤 하여도 계속 따라오지 않고 생성된 자리에 그대로 남아 있도록 수정