### PR TITLE
feature: Markdown 문서 뷰어 실장 (프리뷰/RAW/편집/메모/다운로드)

### DIFF
--- a/EasyDOC-frontend/easydoc-parser/main.py
+++ b/EasyDOC-frontend/easydoc-parser/main.py
@@ -410,8 +410,18 @@ async def parse_from_s3(
         elif ext == "hwpx":
             text = _parse_hwpx_bytes(contents)
 
+        elif ext == "md":
+            for enc in ("utf-8", "euc-kr", "cp949", "latin-1"):
+                try:
+                    text = contents.decode(enc)
+                    break
+                except (UnicodeDecodeError, ValueError):
+                    continue
+            else:
+                text = contents.decode("utf-8", errors="replace")
+
         else:
-            return {"error": "지원하지 않는 파일 형식입니다. (PDF, HWPX, 이미지만 지원)"}
+            return {"error": "지원하지 않는 파일 형식입니다. (PDF, HWPX, MD, 이미지만 지원)"}
 
         # ================= DB 저장 로직 =================
         # 파일 크기 계산

--- a/EasyDOC-frontend/src/pages/MarkdownViewer.jsx
+++ b/EasyDOC-frontend/src/pages/MarkdownViewer.jsx
@@ -1,0 +1,324 @@
+import React, { useState, useRef, useCallback, useEffect } from "react";
+import { createPortal } from "react-dom";
+import ReactMarkdown from "react-markdown";
+import axios from "axios";
+import { Highlighter, X, Eye, Code, Save, Type, Download } from "lucide-react";
+import "./PdfHighlightViewer.css";
+
+const PARSER_URL  = "http://localhost:8000";
+const DOC_API_URL = "http://localhost:8002";
+
+/* ── 쉬운말 팝업 ── */
+function SimplifyPopup({ popup, onClose }) {
+  return createPortal(
+    <div
+      className={`pdf-simplify-popup ${popup.placement === "below" ? "pdf-simplify-popup--below" : ""}`}
+      style={{ position: "fixed", left: popup.x, top: popup.y, transform: "translateX(-50%)", zIndex: 9999 }}
+      onMouseDown={(e) => e.stopPropagation()}
+    >
+      <div className="pdf-simplify-popup-header">
+        <span>쉬운말 변환</span>
+        <button className="pdf-simplify-popup-close" onClick={onClose}><X size={13} /></button>
+      </div>
+      <div className="pdf-simplify-popup-body">
+        <p className="pdf-simplify-popup-label">선택 문장</p>
+        <p className="pdf-simplify-popup-original">{popup.originalText}</p>
+        <p className="pdf-simplify-popup-label">변환 결과</p>
+        {popup.loading ? (
+          <p className="pdf-simplify-popup-loading">Gemini가 쉬운 표현으로 바꾸는 중...</p>
+        ) : popup.error ? (
+          <p className="pdf-simplify-popup-error">{popup.error}</p>
+        ) : (
+          <p className="pdf-simplify-popup-result">{popup.simplifiedText}</p>
+        )}
+      </div>
+    </div>,
+    document.body
+  );
+}
+
+/* ── 드래그 가능한 메모 오버레이 ── */
+function MemoOverlay({ memo, onMove, onDelete, onUpdate }) {
+  const [editing, setEditing] = useState(!memo.text);
+  const isDragging = useRef(false);
+  const startPos   = useRef({});
+
+  const handleMouseDown = (e) => {
+    if (e.button !== 0 || editing) return;
+    e.stopPropagation();
+    isDragging.current = true;
+    startPos.current = { mx: e.clientX, my: e.clientY, ox: memo.x, oy: memo.y };
+    const move = (ev) => {
+      if (!isDragging.current) return;
+      onMove(startPos.current.ox + ev.clientX - startPos.current.mx,
+             startPos.current.oy + ev.clientY - startPos.current.my);
+    };
+    const up = () => { isDragging.current = false; window.removeEventListener("mousemove", move); window.removeEventListener("mouseup", up); };
+    window.addEventListener("mousemove", move);
+    window.addEventListener("mouseup", up);
+  };
+
+  return (
+    <div
+      data-overlay="true"
+      style={{ position: "absolute", left: memo.x, top: memo.y, zIndex: 10, cursor: editing ? "default" : "move" }}
+      onMouseDown={handleMouseDown}
+    >
+      <div style={{ background: "#fef9c3", border: "1px solid #fde047", borderRadius: 4, minWidth: 160, boxShadow: "0 2px 6px rgba(0,0,0,0.15)", position: "relative" }}>
+        <button
+          onClick={() => onDelete()}
+          style={{ position: "absolute", top: -8, right: -8, width: 16, height: 16, borderRadius: "50%", background: "#ef4444", border: "none", color: "#fff", fontSize: 10, cursor: "pointer", display: "flex", alignItems: "center", justifyContent: "center", padding: 0, lineHeight: 1 }}
+        >×</button>
+        {editing ? (
+          <textarea
+            autoFocus
+            value={memo.text}
+            onChange={(e) => onUpdate({ text: e.target.value })}
+            onBlur={() => setEditing(false)}
+            onClick={(e) => e.stopPropagation()}
+            onMouseDown={(e) => e.stopPropagation()}
+            style={{ width: 180, height: 80, border: "none", background: "transparent", resize: "both", padding: 6, fontSize: 12, outline: "none", fontFamily: "inherit" }}
+          />
+        ) : (
+          <div
+            onDoubleClick={(e) => { e.stopPropagation(); setEditing(true); }}
+            style={{ padding: "6px 8px", fontSize: 12, minHeight: 40, whiteSpace: "pre-wrap", wordBreak: "break-word", color: memo.text ? "#333" : "#aaa" }}
+          >
+            {memo.text || "더블클릭하여 메모 입력"}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default function MarkdownViewer({ text, highlightWord, docId, onTextSaved }) {
+  const [mode, setMode]             = useState("preview");
+  const [dragMode, setDragMode]     = useState(false);
+  const [memoMode, setMemoMode]     = useState(false);
+  const [memos, setMemos]           = useState([]);
+  const [editedText, setEditedText] = useState(text ?? "");
+  const [isDirty, setIsDirty]       = useState(false);
+  const [saving, setSaving]         = useState(false);
+  const [saveMsg, setSaveMsg]       = useState("");
+  const [showDownloadMenu, setShowDownloadMenu] = useState(false);
+
+  const [simplifyPopup,  setSimplifyPopup]  = useState(null);
+  const [highlightRects, setHighlightRects] = useState([]);
+  const contentRef = useRef(null);
+
+  useEffect(() => { setEditedText(text ?? ""); setIsDirty(false); }, [text]);
+
+  // 모드 전환 시 종속 상태 초기화
+  const switchMode = (m) => {
+    setMode(m);
+    setDragMode(false);
+    setMemoMode(false);
+    closePopup();
+  };
+
+  const closePopup = useCallback(() => {
+    setSimplifyPopup(null);
+    setHighlightRects([]);
+  }, []);
+
+  /* 저장 */
+  const handleSave = useCallback(async () => {
+    if (!docId || saving) return;
+    setSaving(true); setSaveMsg("");
+    try {
+      await axios.patch(`${DOC_API_URL}/api/documents/${docId}/text`, { text: editedText });
+      setIsDirty(false);
+      setSaveMsg("저장됐습니다.");
+      onTextSaved?.(editedText);
+      setTimeout(() => setSaveMsg(""), 2500);
+    } catch {
+      setSaveMsg("저장에 실패했습니다.");
+    } finally {
+      setSaving(false);
+    }
+  }, [docId, editedText, saving, onTextSaved]);
+
+  /* 다운로드 .md */
+  const downloadMd = () => {
+    const blob = new Blob([editedText], { type: "text/markdown;charset=utf-8" });
+    const url  = URL.createObjectURL(blob);
+    const a    = document.createElement("a");
+    a.href = url; a.download = "document.md"; a.click();
+    URL.revokeObjectURL(url);
+    setShowDownloadMenu(false);
+  };
+
+  /* 다운로드 PDF — 브라우저 인쇄 다이얼로그 */
+  const downloadPdf = () => {
+    setShowDownloadMenu(false);
+    // 프리뷰 모드로 전환 후 인쇄
+    setMode("preview");
+    setTimeout(() => window.print(), 300);
+  };
+
+  /* 메모 CRUD */
+  const addMemo    = (x, y) => setMemos(p => [...p, { id: Date.now(), x, y, text: "" }]);
+  const updateMemo = (id, d) => setMemos(p => p.map(m => m.id === id ? { ...m, ...d } : m));
+  const deleteMemo = (id)    => setMemos(p => p.filter(m => m.id !== id));
+
+  /* 클릭 처리 */
+  const handleContentClick = useCallback((e) => {
+    if (e.target.closest("[data-overlay]")) return;
+    if (!memoMode) return;
+    const rect = contentRef.current.getBoundingClientRect();
+    addMemo(e.clientX - rect.left, e.clientY - rect.top + contentRef.current.scrollTop);
+  }, [memoMode]);
+
+  /* 드래그 → 쉬운말 */
+  const handleMouseUp = useCallback((e) => {
+    if (mode !== "preview" || !dragMode) return;
+    if (e.target.closest(".pdf-simplify-popup") || e.target.closest("[data-overlay]")) return;
+
+    const selection = window.getSelection();
+    const selected  = selection?.toString().trim();
+    if (!selected || selected.length < 2) return;
+    if (selected.length > 500) { selection.removeAllRanges(); alert("500자 이내로 드래그해 주세요."); return; }
+
+    const range       = selection.getRangeAt(0);
+    const clientRects = Array.from(range.getClientRects()).filter(r => r.width > 0);
+    const wrapperRect = contentRef.current.getBoundingClientRect();
+
+    const relRects   = clientRects.map(r => ({ left: r.left - wrapperRect.left, top: r.top - wrapperRect.top, width: r.width, height: r.height }));
+    const first      = clientRects[0];
+    const last       = clientRects[clientRects.length - 1];
+    const vpX        = (first.left + last.right) / 2;
+    const placeBelow = first.top < 140;
+    const vpY        = placeBelow ? last.bottom + 8 : first.top - 8;
+
+    selection.removeAllRanges();
+    setHighlightRects(relRects);
+    setSimplifyPopup({ loading: true, error: null, originalText: selected, simplifiedText: "", x: vpX, y: vpY, placement: placeBelow ? "below" : "above" });
+
+    axios.post(`${PARSER_URL}/chat`, {
+      messages: [{ role: "user", content:
+        "아래 문장을 **사회초년생·청년층**(19~34세, 설명서·계약서·법령 읽기에 어려움을 느끼는 사람)이 한 번에 이해할 수 있도록 쉬운 한국어로 바꿔줘.\n" +
+        "- 한자어·법률용어·행정 전문용어를 일상 표현으로 치환\n원래 의미를 절대 왜곡하지 말 것\n줄바꿈 없이 하나의 이어지는 문단으로 출력\n설명·주석 없이 변환된 문장만 출력\n\n" + selected,
+      }],
+      persona: "default", document_context: "",
+    })
+      .then(res => { const c = (res.data?.reply || "").replace(/\[HL:.+?\]/g, "").trim(); setSimplifyPopup(p => p ? { ...p, loading: false, simplifiedText: c || "변환 결과가 비어 있습니다." } : p); })
+      .catch(() => setSimplifyPopup(p => p ? { ...p, loading: false, error: "변환에 실패했습니다." } : p));
+  }, [mode, dragMode]);
+
+  const handleMouseDown = useCallback((e) => {
+    if (!e.target.closest(".pdf-simplify-popup")) closePopup();
+    setShowDownloadMenu(false);
+  }, [closePopup]);
+
+  /* 버튼 스타일 */
+  const btn = { display: "flex", alignItems: "center", gap: 5, padding: "4px 10px", borderRadius: 6, fontSize: 12, cursor: "pointer", border: "1px solid #d1d5db", background: "#fff", color: "#374151" };
+  const btnOn = { ...btn, border: "1px solid #3D4B90", background: "#eef0fb", color: "#3D4B90", fontWeight: 700 };
+
+  if (text == null) return null;
+
+  const cursor = memoMode ? "crosshair" : dragMode ? "text" : "auto";
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", height: "100%" }}>
+      {/* ── 툴바 ── */}
+      <div style={{ display: "flex", alignItems: "center", gap: 8, padding: "6px 16px", background: "#fff", borderBottom: "1px solid #e5e7eb", flexShrink: 0, flexWrap: "wrap" }}>
+
+        <button onClick={() => switchMode("preview")} style={mode === "preview" ? btnOn : btn}><Eye size={14} /> 프리뷰</button>
+        <button onClick={() => switchMode("raw")} style={mode === "raw" ? btnOn : btn}><Code size={14} /> RAW</button>
+
+        <div style={{ width: 1, height: 20, background: "#e5e7eb", margin: "0 2px" }} />
+
+        {mode === "preview" && (
+          <>
+            <button onClick={() => { setDragMode(v => !v); setMemoMode(false); }} style={dragMode ? btnOn : btn} title="드래그로 쉬운말 변환">
+              <Highlighter size={14} /> 드래그 {dragMode ? "ON" : "OFF"}
+            </button>
+            <button onClick={() => { setMemoMode(v => !v); setDragMode(false); closePopup(); }} style={memoMode ? btnOn : btn} title="클릭하여 메모 추가">
+              <Type size={14} /> 메모
+            </button>
+          </>
+        )}
+
+        {mode === "raw" && (
+          <>
+            <button
+              onClick={handleSave}
+              disabled={!isDirty || saving || !docId}
+              style={{ ...btn, background: isDirty && docId ? "#3D4B90" : "#e5e7eb", color: isDirty && docId ? "#fff" : "#9ca3af", border: "none", cursor: isDirty && docId ? "pointer" : "default" }}
+            >
+              <Save size={14} /> {saving ? "저장 중..." : "저장"}
+            </button>
+            {!docId && <span style={{ fontSize: 11, color: "#f59e0b" }}>DB에 저장된 문서만 수정 가능합니다</span>}
+            {saveMsg && <span style={{ fontSize: 11, color: saveMsg.includes("실패") ? "#dc2626" : "#059669" }}>{saveMsg}</span>}
+          </>
+        )}
+
+        {/* 다운로드 드롭다운 */}
+        <div style={{ position: "relative", marginLeft: "auto" }}>
+          <button onClick={() => setShowDownloadMenu(v => !v)} style={{ ...btn, background: "#3D4B90", color: "#fff", border: "none" }}>
+            <Download size={14} /> 다운로드
+          </button>
+          {showDownloadMenu && (
+            <div style={{ position: "absolute", right: 0, top: "calc(100% + 4px)", background: "#fff", border: "1px solid #e5e7eb", borderRadius: 8, boxShadow: "0 4px 12px rgba(0,0,0,0.12)", zIndex: 100, minWidth: 160, overflow: "hidden" }}>
+              <button onClick={downloadMd} style={{ display: "block", width: "100%", padding: "10px 16px", textAlign: "left", fontSize: 13, background: "none", border: "none", cursor: "pointer", color: "#374151" }}
+                onMouseEnter={e => e.target.style.background = "#f3f4f6"} onMouseLeave={e => e.target.style.background = "none"}>
+                .md 파일로 저장
+              </button>
+              <button onClick={downloadPdf} style={{ display: "block", width: "100%", padding: "10px 16px", textAlign: "left", fontSize: 13, background: "none", border: "none", cursor: "pointer", color: "#374151" }}
+                onMouseEnter={e => e.target.style.background = "#f3f4f6"} onMouseLeave={e => e.target.style.background = "none"}>
+                PDF로 저장 (인쇄)
+              </button>
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* 모드 안내 */}
+      <div style={{ padding: "4px 16px", background: "#f9fafb", borderBottom: "1px solid #f3f4f6", fontSize: 11, color: "#9ca3af", flexShrink: 0 }}>
+        {mode === "preview" && !dragMode && !memoMode && "읽기 전용 · 수정하려면 RAW 모드로 전환하세요"}
+        {mode === "preview" && dragMode && "텍스트를 드래그하면 쉬운말로 변환합니다 (최대 500자)"}
+        {mode === "preview" && memoMode && "내용을 클릭하면 메모를 추가합니다. 더블클릭으로 편집, 드래그로 이동합니다."}
+        {mode === "raw" && "마크다운 원문을 직접 편집할 수 있습니다. 저장하면 DB에 반영됩니다."}
+      </div>
+
+      {/* ── 본문 ── */}
+      {mode === "preview" ? (
+        <div
+          ref={contentRef}
+          style={{ position: "relative", flex: 1, overflowY: "auto", padding: "32px 40px", maxWidth: 800, margin: "0 auto", width: "100%", lineHeight: 1.8, fontSize: 15, color: "#1f2937", userSelect: dragMode ? "text" : "none", cursor }}
+          onClick={handleContentClick}
+          onMouseUp={handleMouseUp}
+          onMouseDown={handleMouseDown}
+        >
+          <ReactMarkdown>{editedText}</ReactMarkdown>
+
+          {/* 드래그 하이라이트 */}
+          {highlightRects.map((r, i) => (
+            <div key={i} style={{ position: "absolute", left: r.left, top: r.top, width: r.width, height: r.height, background: "rgba(255,220,0,0.4)", pointerEvents: "none", zIndex: 5 }} />
+          ))}
+
+          {/* 메모 오버레이 */}
+          {memos.map(memo => (
+            <MemoOverlay
+              key={memo.id}
+              memo={memo}
+              onMove={(x, y) => updateMemo(memo.id, { x, y })}
+              onUpdate={(d) => updateMemo(memo.id, d)}
+              onDelete={() => deleteMemo(memo.id)}
+            />
+          ))}
+        </div>
+      ) : (
+        <textarea
+          value={editedText}
+          onChange={(e) => { setEditedText(e.target.value); setIsDirty(true); }}
+          spellCheck={false}
+          style={{ flex: 1, padding: "24px 32px", fontFamily: "'Consolas', 'Monaco', monospace", fontSize: 13, lineHeight: 1.7, color: "#1f2937", background: "#fafafa", border: "none", outline: "none", resize: "none", overflowY: "auto" }}
+        />
+      )}
+
+      {simplifyPopup && <SimplifyPopup popup={simplifyPopup} onClose={closePopup} />}
+    </div>
+  );
+}

--- a/EasyDOC-frontend/src/pages/Upload.jsx
+++ b/EasyDOC-frontend/src/pages/Upload.jsx
@@ -147,9 +147,9 @@ export default function Upload({
     setShowDocTypeModal(false);
     if (!selectedFile) return;
 
-    // PDF/HWPX 파일이면 원본 렌더링을 위해 블롭 URL 저장
+    // PDF/HWPX/MD 파일이면 원본 렌더링을 위해 블롭 URL 저장
     const _ext = selectedFile.name.split(".").pop().toLowerCase();
-    if (_ext === "pdf" || _ext === "hwpx") {
+    if (_ext === "pdf" || _ext === "hwpx" || _ext === "md") {
       setPdfFileUrl(URL.createObjectURL(selectedFile));
     } else {
       setPdfFileUrl(null);
@@ -264,6 +264,7 @@ export default function Upload({
     const ext = fileName.split(".").pop().toLowerCase();
     if (ext === "pdf") return "pdf";
     if (ext === "hwpx") return "hwp";
+    if (ext === "md") return "md";
     if (["jpg", "jpeg", "png", "gif", "bmp"].includes(ext)) return "image";
     return "default";
   };
@@ -328,6 +329,7 @@ export default function Upload({
                   <div className="recent-item-icon">
                     {getFileIcon(doc.name) === "pdf" && <PDFIcon />}
                     {getFileIcon(doc.name) === "hwp" && <HWPIcon />}
+                    {getFileIcon(doc.name) === "md" && <MDIcon />}
                     {getFileIcon(doc.name) === "image" && <ImageIcon />}
                   </div>
                   <div className="recent-item-info">
@@ -366,6 +368,10 @@ export default function Upload({
                 <span>HWPX</span>
               </div>
               <div className="format-item">
+                <MDIcon />
+                <span>Markdown</span>
+              </div>
+              <div className="format-item">
                 <ImageIcon />
                 <span>이미지</span>
               </div>
@@ -378,7 +384,7 @@ export default function Upload({
             <input
               ref={fileInputRef}
               type="file"
-              accept=".pdf,.hwpx,.jpg,.jpeg,.png,.gif,.bmp"
+              accept=".pdf,.hwpx,.md,.jpg,.jpeg,.png,.gif,.bmp"
               onChange={handleFileSelect}
               className="file-input"
               id="file-input"
@@ -599,6 +605,15 @@ function HWPIcon() {
       >
         HWPX
       </text>
+    </svg>
+  );
+}
+
+function MDIcon() {
+  return (
+    <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <rect x="4" y="4" width="16" height="16" rx="2" fill="#7C3AED" stroke="#7C3AED" strokeWidth="1" />
+      <text x="12" y="16" textAnchor="middle" fill="white" fontSize="8" fontWeight="bold">MD</text>
     </svg>
   );
 }

--- a/EasyDOC-frontend/src/pages/Viewer.jsx
+++ b/EasyDOC-frontend/src/pages/Viewer.jsx
@@ -14,7 +14,7 @@ import {
 } from "lucide-react";
 import PdfHighlightViewer from "./PdfHighlightViewer";
 import HwpxViewer from "./HwpxViewer";
-import ReactMarkdown from "react-markdown";
+import MarkdownViewer from "./MarkdownViewer";
 import AgentChat from "./AgentChat";
 import "./viewer.css";
 import AppBrandLogo from "../components/AppBrandLogo";
@@ -498,9 +498,12 @@ export default function Viewer({
               docType={currentDocType}
             />
           ) : isMd && parsedText ? (
-            <div style={{ padding: 32, maxWidth: 800, margin: "0 auto", lineHeight: 1.8, fontSize: 15, color: "#1f2937" }}>
-              <ReactMarkdown>{parsedText}</ReactMarkdown>
-            </div>
+            <MarkdownViewer
+              text={parsedText}
+              highlightWord={highlightWord}
+              docId={viewerDocId}
+              onTextSaved={(t) => setParsedText(t)}
+            />
           ) : (
             <iframe
               src={pdfUrl}

--- a/EasyDOC-frontend/src/pages/Viewer.jsx
+++ b/EasyDOC-frontend/src/pages/Viewer.jsx
@@ -14,6 +14,7 @@ import {
 } from "lucide-react";
 import PdfHighlightViewer from "./PdfHighlightViewer";
 import HwpxViewer from "./HwpxViewer";
+import ReactMarkdown from "react-markdown";
 import AgentChat from "./AgentChat";
 import "./viewer.css";
 import AppBrandLogo from "../components/AppBrandLogo";
@@ -75,6 +76,7 @@ export default function Viewer({
   const [isPdf, setIsPdf] = useState(false);
   const [isHwpx, setIsHwpx] = useState(false);
   const [isOcr, setIsOcr] = useState(false);
+  const [isMd, setIsMd] = useState(false);
 
   // 최근 문서 목록 상태
   const [recentDocs, setRecentDocs] = useState([]);
@@ -164,6 +166,7 @@ export default function Viewer({
           docData.file_name?.split(".").pop().toLowerCase();
         setIsPdf(ext === "pdf");
         setIsHwpx(ext === "hwpx");
+        setIsMd(ext === "md");
       }
     } catch (error) {
       console.error("문서 상세 로딩 실패:", error);
@@ -210,6 +213,7 @@ export default function Viewer({
         const ext = parsedData?.filename?.split(".").pop().toLowerCase();
         setIsPdf(ext === "pdf");
         setIsHwpx(ext === "hwpx");
+        setIsMd(ext === "md");
         setIsOcr(false);
       }
     }
@@ -245,6 +249,7 @@ export default function Viewer({
     const fileExt = file.name.split(".").pop().toLowerCase();
     setIsPdf(fileExt === "pdf");
     setIsHwpx(fileExt === "hwpx");
+    setIsMd(fileExt === "md");
     setDocumentName(file.name);
     setHighlightWord("");
     setSelectedDoc(null);
@@ -404,6 +409,19 @@ export default function Viewer({
           <div className="header-title">
             <BookOpen size={24} color="#3D4B90" />
             <span>문서</span>
+            {isMd && (
+              <>
+                <span style={{ fontSize: 11, fontWeight: 600, color: "#fff", background: "#7C3AED", borderRadius: 4, padding: "2px 6px", marginLeft: 8 }}>
+                  Markdown 모드
+                </span>
+                <span style={{ fontSize: 11, color: "#9ca3af", marginLeft: 6 }}>
+                  powered by{" "}
+                  <a href="https://github.com/remarkjs/react-markdown" target="_blank" rel="noopener noreferrer" style={{ color: "#6b7280", textDecoration: "underline", cursor: "pointer" }}>
+                    react-markdown
+                  </a>
+                </span>
+              </>
+            )}
             {isOcr && (
               <>
                 <span style={{ fontSize: 11, fontWeight: 600, color: "#fff", background: "#059669", borderRadius: 4, padding: "2px 6px", marginLeft: 8 }}>
@@ -479,6 +497,10 @@ export default function Viewer({
               highlightWord={highlightWord}
               docType={currentDocType}
             />
+          ) : isMd && parsedText ? (
+            <div style={{ padding: 32, maxWidth: 800, margin: "0 auto", lineHeight: 1.8, fontSize: 15, color: "#1f2937" }}>
+              <ReactMarkdown>{parsedText}</ReactMarkdown>
+            </div>
           ) : (
             <iframe
               src={pdfUrl}

--- a/database_document/document_api.py
+++ b/database_document/document_api.py
@@ -169,6 +169,19 @@ def update_difficult_words(doc_id: int, data: DifficultWordsUpdate, db: Session 
 
     return {"message": "어려운 단어 업데이트 성공"}
 
+class TextUpdate(BaseModel):
+    text: str
+
+# 문서 텍스트 수정 저장
+@app.patch("/api/documents/{doc_id}/text")
+def update_document_text(doc_id: int, data: TextUpdate, db: Session = Depends(get_db)):
+    doc = db.query(Document).filter(Document.id == doc_id).first()
+    if not doc:
+        raise HTTPException(status_code=404, detail="문서를 찾을 수 없습니다.")
+    doc.extracted_text = data.text
+    db.commit()
+    return {"message": "텍스트 업데이트 성공"}
+
 if __name__ == "__main__":
     import uvicorn
     uvicorn.run(app, host="0.0.0.0", port=8002)


### PR DESCRIPTION
## 변경 사항
<img width="2524" height="1222" alt="image" src="https://github.com/user-attachments/assets/e5c2891a-c3be-4bc8-80c5-a71fb52fc506" />

---   

### 파서 (`main.py`)
- `.md` 확장자 파싱 추가 — UTF-8/EUC-KR/CP949 순서로 인코딩 자동 감지

### Markdown 뷰어 (`MarkdownViewer.jsx`, 신규)
- **프리뷰 모드**: `react-markdown` 렌더링 (이미 설치된 의존성 재사용)
- **RAW 모드**: 모노스페이스 textarea로 원문 직접 편집
- **저장**: `PATCH /api/documents/:id/text` → DB `extracted_text` 업데이트 (S3 원본 유지)
- **드래그 모드**: 텍스트 선택 → 쉬운말 변환 팝업 (프리뷰 전용)
- **메모**: 클릭으로 포스트잇 추가, 드래그 이동, 더블클릭 편집
- **다운로드**: `.md` 파일 저장 / PDF 저장(브라우저 인쇄)
- 모드별 상태 안내문 표시 (읽기 전용 안내 포함)

### 뷰어 통합 (`Viewer.jsx`, `Upload.jsx`)
- `.md` 확장자 감지 → `MarkdownViewer` 렌더링 분기
- `accept`에 `.md` 추가, 업로드 포맷 목록에 Markdown 아이콘 추가
- 헤더 보라색 `Markdown 모드` 배지 + `powered by react-markdown` 크레딧

### 백엔드 (`document_api.py`)
- `PATCH /api/documents/{doc_id}/text` 엔드포인트 추가

## 설계 메모
- 편집 저장은 DB만 업데이트 (S3 원본 불변) — EasyDOC의 분석 기능이 DB 텍스트 기반이므로 이걸로 충분
- 추가 서버·의존성 없음 (`react-markdown`은 기존 설치)
